### PR TITLE
Add hourly reminders feature for Telegram bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem "telegram-bot-ruby"
 
 gem "byebug"
 
-gem "rufus-scheduler"
+gem "whenever"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem "telegram-bot-ruby"
 
 gem "byebug"
 
+gem "rufus-scheduler"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -43,7 +45,5 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
-  gem 'faker'
+  gem "faker"
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,9 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.3.0)
       net-http
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -178,6 +181,7 @@ GEM
       stringio
     puma (6.4.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
     rack-cors (2.0.2)
@@ -312,6 +316,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 8.0.1)
   rubocop-rails-omakase
+  rufus-scheduler
   sqlite3 (>= 1.4)
   telegram-bot-ruby
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       racc
     builder (3.3.0)
     byebug (11.1.3)
+    chronic (0.10.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -120,9 +121,6 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.3.0)
       net-http
-    fugit (1.11.1)
-      et-orbi (~> 1, >= 1.2.11)
-      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.6)
@@ -181,7 +179,6 @@ GEM
       stringio
     puma (6.4.2)
       nio4r (~> 2.0)
-    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
     rack-cors (2.0.2)
@@ -289,6 +286,8 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.7.1)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   aarch64-linux
@@ -316,10 +315,10 @@ DEPENDENCIES
   rack-cors
   rails (~> 8.0.1)
   rubocop-rails-omakase
-  rufus-scheduler
   sqlite3 (>= 1.4)
   telegram-bot-ruby
   tzinfo-data
+  whenever
 
 BUNDLED WITH
    2.5.18

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,0 +1,2 @@
+class Reminder < ApplicationRecord
+end

--- a/app/services/telegram_bot_service.rb
+++ b/app/services/telegram_bot_service.rb
@@ -88,7 +88,6 @@ class TelegramBotService
       responseString << "\nTotal amount spent: $#{totalAmount}"
       @bot.api.send_message(chat_id: message.chat.id, text: responseString)
     when "/delete"
-      # To be handled. Delete last added transaction?
       lastExpense = Expense.where("user_id LIKE ?", "%#{user.id}%").order(id: :desc).first
       if lastExpense
         lastExpense.destroy
@@ -96,16 +95,47 @@ class TelegramBotService
       end
     when "/remind"
       begin
-        result = TelegramRemindersService.create_reminder(user_id: user.id, hour: Integer(content))
-        puts result
-        if result.key?(:success)
-          puts "Successfully created a reminder"
-        else
-          puts "Create reminder failed"
-        end
+        handle_reminder_commands(user.id, message.chat.id, content)
       rescue ArgumentError => e
         puts "Error at create_reminder: #{e.message}"
+        puts "Error at handle_reminder_commands: #{e.message}"
       end
+    end
+  end
+
+  private def handle_reminder_commands(user_id, chat_id, content)
+    if content.contains("create")
+      _, hour = content.split(" ", 2)
+      result = TelegramRemindersService.create_reminder(user_id: user.id, hour: Integer(hour))
+      if result.key?(:success)
+        @bot.api.send_message(chat_id: chat_id, text: "New reminder created for #{hour}!")
+      else
+        @bot.api.send_message(chat_id: chat_id, text: "Sorry, please try again. #{result.error}")
+      end
+    elsif content.contains("delete")
+      _, hour = content.split(" ", 2)
+      TelegramRemindersService.delete_reminder(user_id: user.id, hour: hour)
+      if result.key?(:success)
+        @bot.api.send_message(chat_id: chat_id, text: "Reminder deleted for #{hour}!")
+      else
+        @bot.api.send_message(chat_id: chat_id, text: "Sorry, please try again. #{result.error}")
+      end
+    elsif content.contains ("list")
+      maxListed = 10
+      remindersArray = TelegramRemindersService.get_reminders_for_user_id(user_id)
+      responseString = "Here is your list of reminders!\n\n"
+      remindersArray.each_with_index do |expense, i|
+        if i < maxListed
+          responseString << "#{i+1}: #{reminder.hour}\n"
+        end
+      end
+      if remindersArray.length > maxListed
+        responseString << "...\n"
+      end
+      @bot.api.send_message(chat_id: chat_id, text: responseString)
+    else
+      responseString = "Sorry, I couldn't understand that. Please use either 'create n', 'delete n' or 'list'."
+      @bot.api.send_message(chat_id: chat_id, text: responseString)
     end
   end
 

--- a/app/services/telegram_bot_service.rb
+++ b/app/services/telegram_bot_service.rb
@@ -17,29 +17,26 @@ class TelegramBotService
 
         user = User.find_by_id(message.from.id)
 
-        if !user
-          if message.text == "/register"
-            User.create(id: message.from.id, registration_state: "awaiting_email")
-            bot.api.send_message(chat_id: message.chat.id, text: "Please enter your email")
-          else
-            bot.api.send_message(
-              chat_id: message.chat.id, text: "Unregistered. Please use /register to sign up."
-            )
-          end
-          next
-        end
+        begin
 
-        case user.registration_state
-        when "registered"
-          if message.is_a?(Telegram::Bot::Types::Message)
-            if message.edit_date
-              handle_edited_flow user, message
-            else
-              handle_message_flow user, message
-            end
+          if !user
+            user = User.create(id: message.from.id, registration_state: RegistrationState::AWAITING_EMAIL)
+            @bot.api.send_message(chat_id: message.from.id, text: "Please enter your email.")
           else
-            handle_registration user, message
+            case user.registration_state
+            when RegistrationState::REGISTERED
+              if message.edit_date
+                handle_edited_flow user, message
+              else
+                handle_message_flow user, message
+              end
+            else
+              handle_registration user, message
+            end
           end
+
+        rescue Exception => e
+          puts "🚨 PLEASE FIX! 🚨 Something was wrong: #{e.message}"
         end
       end
     end
@@ -51,7 +48,7 @@ class TelegramBotService
 
     case command
     when "/start"
-      @bot.api.send_message(chat_id: message.chat.id, text: "To create a new transaction, type /new [item name]-[item amount]!")
+      @bot.api.send_message(chat_id: message.chat.id, text: "/new [item name]-[item amount]\n/list\n/delete\n/remind [remind command]")
     when "/new"
       begin
         expenseData = content.split("-")  # remove /new from string?
@@ -94,12 +91,11 @@ class TelegramBotService
         @bot.api.send_message(chat_id: message.chat.id, text: "Last expense deleted: #{lastExpense.title}, $#{lastExpense.amount}")
       end
     when "/remind"
-      begin
+      if !content.nil?
         handle_reminder_commands(user.id, message.chat.id, content)
-      rescue ArgumentError => e
-        puts "Error at create_reminder: #{e.message}"
-        puts "Error at handle_reminder_commands: #{e.message}"
       end
+    else
+      handle_unknown_command(message.chat.id)
     end
   end
 
@@ -132,9 +128,6 @@ class TelegramBotService
       if remindersArray.length > maxListed
         responseString << "...\n"
       end
-      @bot.api.send_message(chat_id: chat_id, text: responseString)
-    else
-      responseString = "Sorry, I couldn't understand that. Please use either 'create n', 'delete n' or 'list'."
       @bot.api.send_message(chat_id: chat_id, text: responseString)
     end
   end
@@ -173,15 +166,25 @@ class TelegramBotService
 
   def handle_registration(user, message)
     case user.registration_state
-    when "awaiting_email"
-      user.update(email: message.text, registration_state: "awaiting_password")
+    when RegistrationState::AWAITING_EMAIL
+      user.update(email: message.text, registration_state: RegistrationState::AWAITING_PASSWORD)
       @bot.api.send_message(chat_id: message.chat.id, text: "Please enter your password")
-    when "awaiting_password"
-      user.update(password_hash: message.text, registration_state: "registered")
+    when RegistrationState::AWAITING_PASSWORD
+      user.update(password_hash: message.text, registration_state: RegistrationState::REGISTERED)
       @bot.api.send_message(chat_id: message.chat.id, text: "Registration complete!")
     else
-      @bot.api.send_message(chat_id: message.chat.id, text: "Unregistered. Please use /register to sign up.")
+      @bot.api.send_message(chat_id: message.chat.id, text: "Hi! Please create an account by entering your email.")
     end
+  end
+
+  def handle_unknown_command(chat_id)
+    @bot.api.send_message(chat_id: chat_id, text: "Sorry I didn't get that. Make sure you're using one of the pre-defined commands, or type /start to see the list of commands.")
+  end
+
+  module RegistrationState
+    AWAITING_EMAIL = "awaiting_email"
+    AWAITING_PASSWORD = "awaiting_password"
+    REGISTERED = "registered"
   end
 end
 

--- a/app/services/telegram_bot_service.rb
+++ b/app/services/telegram_bot_service.rb
@@ -36,7 +36,7 @@ class TelegramBotService
           end
 
         rescue Exception => e
-          puts "🚨 PLEASE FIX! 🚨 Something was wrong: #{e.message}"
+          puts "🚨 PLEASE FIX! 🚨 Something was wrong: #{e.inspect}\n#{e.backtrace_locations.first()}"
         end
       end
     end
@@ -91,44 +91,47 @@ class TelegramBotService
         @bot.api.send_message(chat_id: message.chat.id, text: "Last expense deleted: #{lastExpense.title}, $#{lastExpense.amount}")
       end
     when "/remind"
-      if !content.nil?
         handle_reminder_commands(user.id, message.chat.id, content)
-      end
     else
       handle_unknown_command(message.chat.id)
     end
   end
 
   private def handle_reminder_commands(user_id, chat_id, content)
-    if content.contains("create")
+    if content.nil?
+      @bot.api.send_message(chat_id: chat_id, text: "The /remind commands are:\ncreate [hour]\ndelete [hour]\nlist")
+    elsif content.include? ("create")
       _, hour = content.split(" ", 2)
-      result = TelegramRemindersService.create_reminder(user_id: user.id, hour: Integer(hour))
+      result = TelegramRemindersService.create_reminder(user_id: user_id, hour: Integer(hour))
       if result.key?(:success)
         @bot.api.send_message(chat_id: chat_id, text: "New reminder created for #{hour}!")
       else
         @bot.api.send_message(chat_id: chat_id, text: "Sorry, please try again. #{result.error}")
       end
-    elsif content.contains("delete")
+    elsif content.include? ("delete")
       _, hour = content.split(" ", 2)
-      TelegramRemindersService.delete_reminder(user_id: user.id, hour: hour)
+      result = TelegramRemindersService.delete_reminder(user_id: user_id, hour: hour)
       if result.key?(:success)
         @bot.api.send_message(chat_id: chat_id, text: "Reminder deleted for #{hour}!")
       else
         @bot.api.send_message(chat_id: chat_id, text: "Sorry, please try again. #{result.error}")
       end
-    elsif content.contains ("list")
+    elsif content.include? ("list")
+      puts "remind list"
       maxListed = 10
       remindersArray = TelegramRemindersService.get_reminders_for_user_id(user_id)
       responseString = "Here is your list of reminders!\n\n"
-      remindersArray.each_with_index do |expense, i|
+      remindersArray.each_with_index do |reminder, i|
         if i < maxListed
-          responseString << "#{i+1}: #{reminder.hour}\n"
+          responseString << "#{i+1}: #{reminder}\n"
         end
       end
       if remindersArray.length > maxListed
         responseString << "...\n"
       end
       @bot.api.send_message(chat_id: chat_id, text: responseString)
+    else
+      @bot.api.send_message(chat_id: chat_id, text: "The /remind commands are:\ncreate [hour]\ndelete [hour]\nlist")
     end
   end
 

--- a/app/services/telegram_bot_service.rb
+++ b/app/services/telegram_bot_service.rb
@@ -94,6 +94,18 @@ class TelegramBotService
         lastExpense.destroy
         @bot.api.send_message(chat_id: message.chat.id, text: "Last expense deleted: #{lastExpense.title}, $#{lastExpense.amount}")
       end
+    when "/remind"
+      begin
+        result = TelegramRemindersService.create_reminder(user_id: user.id, hour: Integer(content))
+        puts result
+        if result.key?(:success)
+          puts "Successfully created a reminder"
+        else
+          puts "Create reminder failed"
+        end
+      rescue ArgumentError => e
+        puts "Error at create_reminder: #{e.message}"
+      end
     end
   end
 

--- a/app/services/telegram_bot_service.rb
+++ b/app/services/telegram_bot_service.rb
@@ -18,7 +18,6 @@ class TelegramBotService
         user = User.find_by_id(message.from.id)
 
         begin
-
           if !user
             user = User.create(id: message.from.id, registration_state: RegistrationState::AWAITING_EMAIL)
             @bot.api.send_message(chat_id: message.from.id, text: "Please enter your email.")
@@ -34,7 +33,6 @@ class TelegramBotService
               handle_registration user, message
             end
           end
-
         rescue Exception => e
           puts "🚨 PLEASE FIX! 🚨 Something was wrong: #{e.inspect}\n#{e.backtrace_locations.first()}"
         end

--- a/app/services/telegram_reminders_service.rb
+++ b/app/services/telegram_reminders_service.rb
@@ -24,4 +24,8 @@ class TelegramRemindersService
     current_hour = Time.now.hour
     Reminder.where(hour: current_hour).pluck(:user)
   end
+
+  def self.get_reminders_for_user_id(user_id: string)
+    Reminder.where(user_id: user_id).pluck(:hour)
+  end
 end

--- a/app/services/telegram_reminders_service.rb
+++ b/app/services/telegram_reminders_service.rb
@@ -2,6 +2,7 @@
 
 class TelegramRemindersService
   def self.create_reminder(user_id: string, hour: int)
+    puts "Create_reminder"
     reminder = Reminder.create(user: user_id, hour: hour)
     if reminder.persisted?
       { success: reminder }
@@ -25,7 +26,7 @@ class TelegramRemindersService
     Reminder.where(hour: current_hour).pluck(:user)
   end
 
-  def self.get_reminders_for_user_id(user_id: string)
-    Reminder.where(user_id: user_id).pluck(:hour)
+  def self.get_reminders_for_user_id(user_id)
+    Reminder.where(user: user_id).pluck(:hour)
   end
 end

--- a/app/services/telegram_reminders_service.rb
+++ b/app/services/telegram_reminders_service.rb
@@ -1,0 +1,27 @@
+# This file contains CRUD methods for Telegram bot reminders
+
+class TelegramRemindersService
+  def self.create_reminder(user_id: string, hour: int)
+    reminder = Reminder.create(user: user_id, hour: hour)
+    if reminder.presisted?
+      { success: reminder }
+    else
+      { error: reminder.errors.full_messages }
+    end
+  end
+
+  def self.delete_reminder(user_id: string, hour: int)
+    reminder = Reminder.find_by(user: user_id, hour: hour)
+    if reminder
+      reminder.destroy
+      { success: "Successfully destroyed" }
+    else
+      { error: "Reminder not found" }
+    end
+  end
+
+  def self.get_users_for_current_hour
+    current_hour = Time.now.hour
+    Reminder.where(hour: current_hour).pluck(:user)
+  end
+end

--- a/app/services/telegram_reminders_service.rb
+++ b/app/services/telegram_reminders_service.rb
@@ -3,7 +3,7 @@
 class TelegramRemindersService
   def self.create_reminder(user_id: string, hour: int)
     reminder = Reminder.create(user: user_id, hour: hour)
-    if reminder.presisted?
+    if reminder.persisted?
       { success: reminder }
     else
       { error: reminder.errors.full_messages }
@@ -20,7 +20,7 @@ class TelegramRemindersService
     end
   end
 
-  def self.get_users_for_current_hour
+  def self.get_user_ids_for_current_hour
     current_hour = Time.now.hour
     Reminder.where(hour: current_hour).pluck(:user)
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,6 +12,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,26 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+set :output, "log/cron_log.log"
+
+every 1.minutes do  # for testing only, switch to '0 * * * *' when done
+  rake "reminders:send"
+end

--- a/db/migrate/20241111140034_create_reminders.rb
+++ b/db/migrate/20241111140034_create_reminders.rb
@@ -1,0 +1,16 @@
+class CreateReminders < ActiveRecord::Migration[7.2]
+  def change
+    if table_exists?(:reminders)
+      drop_table :reminders
+    end
+
+    create_table :reminders do |t|
+      t.string :user
+      t.integer :hour
+
+      t.timestamps
+    end
+
+    add_check_constraint :reminders, 'hour >= 0 AND hour <= 23', name: 'check_hour_range'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_29_142049) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_11_140034) do
   create_table "expenses", force: :cascade do |t|
     t.decimal "amount"
     t.datetime "time"
@@ -19,6 +19,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_29_142049) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.string "message_id"
+  end
+
+  create_table "reminders", force: :cascade do |t|
+    t.string "user"
+    t.integer "hour"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.check_constraint "hour >= 0 AND hour <= 23", name: "check_hour_range"
   end
 
   create_table "users", force: :cascade do |t|

--- a/dev
+++ b/dev
@@ -30,10 +30,6 @@ elif [ "$1" == "bot" ]
 then
   echo Starting Telegram bot
   docker run --name happybara_telegram_bot $config bundle exec rake telegram_bot:bot
-elif [ "$1" == "reminders" ]
-then
-  echo Starting daily reminders for Telegram bot
-  docker run --name happybara_daily_reminders $config bundle exec rake daily_reminders:remind
 else
   echo Running custom command: "$@"
   docker run --name "happybara-$1-$(date +'%m%dT%H%M%S')" $config "$@"

--- a/dev
+++ b/dev
@@ -30,6 +30,10 @@ elif [ "$1" == "bot" ]
 then
   echo Starting Telegram bot
   docker run --name happybara_telegram_bot $config bundle exec rake telegram_bot:bot
+elif [ "$1" == "reminders" ]
+then
+  echo Starting daily reminders for Telegram bot
+  docker run --name happybara_daily_reminders $config bundle exec rake daily_reminders:remind
 else
   echo Running custom command: "$@"
   docker run --name "happybara-$1-$(date +'%m%dT%H%M%S')" $config "$@"

--- a/lib/tasks/telegram_bot.rake
+++ b/lib/tasks/telegram_bot.rake
@@ -1,4 +1,4 @@
-require 'telegram/bot'
+require "telegram/bot"
 
 namespace :telegram_bot do
   desc "Start the Telegram bot"

--- a/lib/tasks/telegram_bot_reminder.rake
+++ b/lib/tasks/telegram_bot_reminder.rake
@@ -1,5 +1,5 @@
 require "telegram/bot"
-require "rufus-scheduler"
+require "rufus/scheduler"
 
 TOKEN = Rails.application.credentials.dig(:telegram_bot_key)
 
@@ -31,13 +31,18 @@ end
 def remind_every_hour
   scheduler = Rufus::Scheduler.new
 
-  scheduler.cron "0 * * * *" do
-    users = TelegramRemindersService.get_users_for_current_hour()
-    users.each do |user|
-      userId = user.id
-      Telegram::Bot::Client.run(TOKEN) do |bot|
-        bot.api.send_message(chat_id: userId, text: "Add your expenses for today!")
+  # scheduler.cron "0 * * * *" do
+  scheduler.every "10s" do
+    puts "TELEGRAM_BOT_REMINDER: executing reminders service --->"
+    Telegram::Bot::Client.run(TOKEN) do |bot|
+      user_ids = TelegramRemindersService.get_user_ids_for_current_hour()
+      puts "TELEGRAM_BOT_REMINDER: No of users = #{user_ids.count}"
+      user_ids.each do |id|
+        puts "    Sending reminder to #{id}"
+        bot.api.send_message(chat_id: id, text: "Add your expenses for today!")
       end
     end
   end
+
+  scheduler.join
 end

--- a/lib/tasks/telegram_bot_reminder.rake
+++ b/lib/tasks/telegram_bot_reminder.rake
@@ -32,7 +32,7 @@ def remind_every_hour
   scheduler = Rufus::Scheduler.new
 
   scheduler.cron "0 * * * *" do
-    users = get_user_for_hour()
+    users = TelegramRemindersService.get_users_for_current_hour()
     users.each do |user|
       userId = user.id
       Telegram::Bot::Client.run(TOKEN) do |bot|
@@ -40,9 +40,4 @@ def remind_every_hour
       end
     end
   end
-end
-
-private def get_user_for_hour
-  current_hour = Time.now.hour
-  Reminder.where(hour: current_hour).pluck(:user)
 end

--- a/lib/tasks/telegram_bot_reminder.rake
+++ b/lib/tasks/telegram_bot_reminder.rake
@@ -1,0 +1,48 @@
+require "telegram/bot"
+require "rufus-scheduler"
+
+TOKEN = Rails.application.credentials.dig(:telegram_bot_key)
+
+namespace :daily_reminders do
+  desc "Execute daily reminders on Telegram"
+  task remind: :environment do
+    RESTART_DELAY = 2
+    def restart_bot(delay)
+      Rails.logger.info "Restarting bot in #{delay} seconds..."
+      delay.downto(1) do |i|
+        Rails.logger.info i
+        sleep 1
+      end
+      Rails.logger.info "Restarting..."
+    end
+
+    loop do
+      begin
+        remind_every_hour()
+      rescue StandardError => e
+        Rails.logger.error "An error occurred: #{e.message}"
+        Rails.logger.error e.backtrace.join("\n")
+        restart_bot(RESTART_DELAY)
+      end
+    end
+  end
+end
+
+def remind_every_hour
+  scheduler = Rufus::Scheduler.new
+
+  scheduler.cron "0 * * * *" do
+    users = get_user_for_hour()
+    users.each do |user|
+      userId = user.id
+      Telegram::Bot::Client.run(TOKEN) do |bot|
+        bot.api.send_message(chat_id: userId, text: "Add your expenses for today!")
+      end
+    end
+  end
+end
+
+private def get_user_for_hour
+  current_hour = Time.now.hour
+  Reminder.where(hour: current_hour).pluck(:user)
+end

--- a/lib/tasks/telegram_bot_reminder.rake
+++ b/lib/tasks/telegram_bot_reminder.rake
@@ -1,48 +1,22 @@
-require "telegram/bot"
-require "rufus/scheduler"
+require "net/http"
+require "json"
 
-TOKEN = Rails.application.credentials.dig(:telegram_bot_key)
 
-namespace :daily_reminders do
+namespace :reminders do
   desc "Execute daily reminders on Telegram"
-  task remind: :environment do
-    RESTART_DELAY = 2
-    def restart_bot(delay)
-      Rails.logger.info "Restarting bot in #{delay} seconds..."
-      delay.downto(1) do |i|
-        Rails.logger.info i
-        sleep 1
-      end
-      Rails.logger.info "Restarting..."
-    end
-
-    loop do
-      begin
-        remind_every_hour()
-      rescue StandardError => e
-        Rails.logger.error "An error occurred: #{e.message}"
-        Rails.logger.error e.backtrace.join("\n")
-        restart_bot(RESTART_DELAY)
-      end
-    end
+  task send: :environment do
+    sendReminders
   end
 end
 
-def remind_every_hour
-  scheduler = Rufus::Scheduler.new
-
-  # scheduler.cron "0 * * * *" do
-  scheduler.every "10s" do
-    puts "TELEGRAM_BOT_REMINDER: executing reminders service --->"
-    Telegram::Bot::Client.run(TOKEN) do |bot|
-      user_ids = TelegramRemindersService.get_user_ids_for_current_hour()
-      puts "TELEGRAM_BOT_REMINDER: No of users = #{user_ids.count}"
-      user_ids.each do |id|
-        puts "    Sending reminder to #{id}"
-        bot.api.send_message(chat_id: id, text: "Add your expenses for today!")
-      end
-    end
+def sendReminders
+  user_ids = TelegramRemindersService.get_user_ids_for_current_hour
+  puts "user_ids: #{user_ids}"
+  message = "here's your reminder to add your expenses!"
+  for id in user_ids
+    data = { chat_id: id, text: message }.to_json
+    url = URI.parse("https://api.telegram.org/bot#{TOKEN}/sendMessage")
+    response = Net::HTTP.post(url, data, { "Content-Type" => "application/json" })
+    puts JSON.parse(response.body)
   end
-
-  scheduler.join
 end

--- a/test/fixtures/reminders.yml
+++ b/test/fixtures/reminders.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/reminder_test.rb
+++ b/test/models/reminder_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReminderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
NOTE: Change merge to `main` after crud branch is merged.

- [x] Create Reminder model
- [x] Write the services script
- [x] Write CRUD for Reminder model
- [x] Write relevant telegram bot commands
- [ ] Test feature manually
- [x] Fix issue where Telegram message is repeatedly sent if error is generated
- [x] Refactor

Feature: Each user to be able to curate their own set of reminders via the telegram bot. Each reminder contains just one point of customisation (time of day by hour) for now; this means all reminders occur daily.